### PR TITLE
Use 21.08 Freedesktop runtime

### DIFF
--- a/co.headsetapp.headset.yml
+++ b/co.headsetapp.headset.yml
@@ -1,8 +1,8 @@
 id: co.headsetapp.headset
 base: org.electronjs.Electron2.BaseApp
-base-version: '19.08'
+base-version: '21.08'
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 command: headset
 finish-args:


### PR DESCRIPTION
19.08 was deprecated a while ago. It works fine on my Ubuntu install but might be good to have another person test it first.