### PR TITLE
fix: use x11 as fallback

### DIFF
--- a/co.headsetapp.headset.yml
+++ b/co.headsetapp.headset.yml
@@ -1,12 +1,13 @@
 id: co.headsetapp.headset
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: headset
 finish-args:
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc
   - --device=dri
   - --socket=pulseaudio


### PR DESCRIPTION
We support wayland, so there's no need to force X11 on flatpak